### PR TITLE
Adding wafv2:GetSampledRequests

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -194,6 +194,7 @@ DataAccess:
   - sso:SearchUsers
   - support:DescribeAttachment
   - support:DescribeCommunications
+  - wafv2:GetSampledRequests
   - workdocs:GetDocument
   - workdocs:GetDocumentPath
   - workdocs:GetDocumentVersion


### PR DESCRIPTION
get-sampled-requests: "Gets detailed information about a specified number of requests--a sample--that WAF randomly selects from among the first 5,000 requests that your Amazon Web Services resource received during a time range that you choose."

These samples include request headers, which might contain sensitive data such as authentication headers.