### PR TITLE
Expand risk of kms:CreateGrant.

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -158,6 +158,7 @@ DataAccess:
   - kinesis:GetRecords
   - kinesisvideo:GetImages
   - kinesisvideo:GetMedia
+  - kms:CreateGrant
   - lambda:GetFunction
   - lambda:GetLayerVersion
   - lightsail:GetContainerImages
@@ -230,6 +231,7 @@ PrivEsc:
   - iam:SetDefaultPolicyVersion
   - iam:UpdateAssumeRolePolicy
   - iam:UpdateLoginProfile
+  - kms:CreateGrant
 
 ResourceExposure:
   Actions:


### PR DESCRIPTION
Added to DataAccess list because it can be used to grant the Decrypt permission, which can be used to access encrypted data:
https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations

Added to PrivEsc list because it can grant permissions that the granting principal doesn't have:
https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#about-grants