### PR TITLE
Adding s3:GetDataAccess

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -38,6 +38,7 @@ CredentialExposure:
   - mediapackage:RotateIngestEndpointCredentials
   - rds-db:connect
   - redshift:GetClusterCredentials
+  - s3:GetDataAccess
   - snowball:GetJobUnlockCode
   - sso-directory:ListBearerTokens
   - storagegateway:DescribeChapCredentials


### PR DESCRIPTION
`s3:GetDataAccess` is part of S3 Access Grants functionality. It vends temporary credentials that allow access to S3 objects.